### PR TITLE
Enabling ES6 for ResourceLoader validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+	"require": {
+		"mck89/peast": "^1.16"
+	},
 	"require-dev": {
 		"liquipedia/sqllint": "*",
 		"mediawiki/mediawiki-codesniffer": "*",

--- a/src/ResourceLoader/ResourceLoaderArticlesModule.php
+++ b/src/ResourceLoader/ResourceLoaderArticlesModule.php
@@ -71,7 +71,7 @@ class ResourceLoaderArticlesModule extends ResourceLoaderWikiModule {
 			$cache::TTL_WEEK,
 			static function () use ( $contents, $fileName ) {
 				try {
-					Peast::ES2016( $contents )->parse();
+					Peast::ES2020( $contents )->parse();
 				} catch ( PeastSyntaxException $e ) {
 					return $e->getMessage() . " on line " . $e->getPosition()->getLine();
 				}
@@ -87,7 +87,7 @@ class ResourceLoaderArticlesModule extends ResourceLoaderWikiModule {
 			// the response itself.
 			return 'mw.log.error(' .
 				json_encode(
-					'Parse error: ' . $error
+					'Parse error: ' . $error . ' for file ' . $fileName
 				) .
 				');';
 		}


### PR DESCRIPTION
## Description

This enables the loading of ES6 scripts using the resource loader by overriding the current script validation with the new one developed by MediaWiki.
It is a duplicate of [the new MediaWiki version](https://gerrit.wikimedia.org/g/mediawiki/core/+/6fd9245f4ce47a77dc76f70994952cd6da2d1db7/includes/ResourceLoader/Module.php#1083) and uses [Peast](https://packagist.org/packages/mck89/peast) for the script validation.

## Testing

Tested on my dev environment using script from Lua Modules and some tests using arrow functions (proper to ES6)

## Notes
The composer.local.json must be updated to consider this new dependency (peast) to work.