### PR TITLE
allow usage of Common.css/FooBar.less files

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "ResourceLoaderArticles",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"author": [
 		"[https://fo-nttax.de Alex Winkler]"
 	],

--- a/src/ResourceLoader/ResourceLoaderArticlesModule.php
+++ b/src/ResourceLoader/ResourceLoaderArticlesModule.php
@@ -38,7 +38,7 @@ class ResourceLoaderArticlesModule extends ResourceLoaderWikiModule {
 		foreach ( $articles as $article ) {
 			if ( substr( $article, -3 ) === '.js' ) {
 				$pages[ 'MediaWiki:Common.js/' . $article ] = [ 'type' => 'script' ];
-			} elseif ( substr( $article, -4 ) === '.css' ) {
+			} elseif ( substr( $article, -4 ) === '.css' || substr( $article, -5 ) === '.less' ) {
 				$pages[ 'MediaWiki:Common.css/' . $article ] = [ 'type' => 'style' ];
 			}
 		}

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -142,7 +142,10 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			);
 			$store = false;
 		} elseif (
-			( substr( $formData[ 'Page' ], -4 ) !== '.css' && $formData[ 'Type' ] === 'style' )
+			(
+				( substr( $formData[ 'Page' ], -4 ) !== '.css' || substr( $formData[ 'Page' ], -5 ) !== '.less' )
+				&& $formData[ 'Type' ] === 'style'
+			)
 			|| ( substr( $formData[ 'Page' ], -3 ) !== '.js' && $formData[ 'Type' ] === 'script' )
 		) {
 			$output->addWikiTextAsContent(
@@ -236,7 +239,10 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			);
 			$store = false;
 		} elseif (
-			( substr( $formData[ 'Page' ], -4 ) !== '.css' && $formData[ 'Type' ] === 'style' )
+			(
+				( substr( $formData[ 'Page' ], -4 ) !== '.css' || substr( $formData[ 'Page' ], -5 ) !== '.less' )
+				&& $formData[ 'Type' ] === 'style'
+			)
 			|| ( substr( $formData[ 'Page' ], -3 ) !== '.js' && $formData[ 'Type' ] === 'script' )
 		) {
 			$output->addWikiTextAsContent(


### PR DESCRIPTION
This allows to denote Less files as `.less` and load it through the system. `.css` files are still parsed as Less too, we can clean that up once we moved all less files to the `.less` extension.