### PR TITLE
Add `priority` field to loaded resources for fine-grained load ordering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
 			"minus-x fix .",
 			"phpcbf"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -28,5 +28,7 @@
 	"resourceloaderarticles-error-wiki-empty": "The wiki parameter cannot be empty!",
 	"resourceloaderarticles-success-add": "Page successfully added",
 	"resourceloaderarticles-success-edit": "Page successfully edited",
-	"resourceloaderarticles-success-delete": "Page successfully deleted"
+	"resourceloaderarticles-success-delete": "Page successfully deleted",
+
+	"resourceloaderarticles-help-priority": "Priority for loading order of the resource (higher first), falls back to alphabetic order within a single priority class."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,9 +18,13 @@
 	"resourceloaderarticles-page": "Page",
 	"resourceloaderarticles-wiki": "Wiki",
 	"resourceloaderarticles-type": "Type",
+	"resourceloaderarticles-priority": "Priority",
+	"resourceloaderarticles-id": "ID",
 
 	"resourceloaderarticles-error-page-empty": "The page parameter cannot be empty!",
 	"resourceloaderarticles-error-page-invalid": "The page name is invalid!",
+	"resourceloaderarticles-error-priority-empty": "The priority parameter cannot be empty!",
+	"resourceloaderarticles-error-priority-invalid": "The priority is invalid - must be an integer!",
 	"resourceloaderarticles-error-wiki-empty": "The wiki parameter cannot be empty!",
 	"resourceloaderarticles-success-add": "Page successfully added",
 	"resourceloaderarticles-success-edit": "Page successfully edited",

--- a/sql/resourceloaderarticles.sql
+++ b/sql/resourceloaderarticles.sql
@@ -2,13 +2,15 @@ CREATE TABLE IF NOT EXISTS /*_*/resourceloaderarticles (
   `rla_id` int(11) NOT NULL,
   `rla_wiki` VARBINARY(255) NOT NULL,
   `rla_page` VARBINARY(255) NOT NULL,
-  `rla_type` VARBINARY(255) NOT NULL
+  `rla_type` VARBINARY(255) NOT NULL,
+  `rla_priority` int(11) NOT NULL
 ) /*$wgDBTableOptions*/;
 
 ALTER TABLE /*_*/resourceloaderarticles
   ADD PRIMARY KEY `rla_id` (`rla_id`),
   ADD KEY `rla_type` (`rla_type`),
-  ADD KEY `rla_wiki` (`rla_wiki`);
+  ADD KEY `rla_wiki` (`rla_wiki`),
+  ADD KEY `rla_priority` (`rla_priority`);
 
 ALTER TABLE /*_*/resourceloaderarticles
   MODIFY `rla_id` int(11) NOT NULL AUTO_INCREMENT;

--- a/sql/resourceloaderarticlesPriorityMigration.sql
+++ b/sql/resourceloaderarticlesPriorityMigration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE resourceloaderarticles
+  ADD COLUMN IF NOT EXISTS `rla_priority` int(11) NOT NULL;

--- a/sql/resourceloaderarticlesPriorityMigration.sql
+++ b/sql/resourceloaderarticlesPriorityMigration.sql
@@ -1,2 +1,3 @@
 ALTER TABLE /*_*/resourceloaderarticles
   ADD COLUMN IF NOT EXISTS `rla_priority` int(11) NOT NULL;
+ UPDATE /*_*/resourceloaderarticles SET `rla_priority` = 100;

--- a/sql/resourceloaderarticlesPriorityMigration.sql
+++ b/sql/resourceloaderarticlesPriorityMigration.sql
@@ -1,3 +1,3 @@
 ALTER TABLE /*_*/resourceloaderarticles
   ADD COLUMN IF NOT EXISTS `rla_priority` int(11) NOT NULL;
- UPDATE /*_*/resourceloaderarticles SET `rla_priority` = 100;
+ UPDATE /*_*/resourceloaderarticles SET `rla_priority` = 0;

--- a/sql/resourceloaderarticlesPriorityMigration.sql
+++ b/sql/resourceloaderarticlesPriorityMigration.sql
@@ -1,2 +1,2 @@
-ALTER TABLE resourceloaderarticles
+ALTER TABLE /*_*/resourceloaderarticles
   ADD COLUMN IF NOT EXISTS `rla_priority` int(11) NOT NULL;

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -43,7 +43,7 @@ class MainHookHandler implements
 				'*',
 				[ '`rla_wiki` IN(\'' . $scriptPath . '\', \'all\')' ],
 				__METHOD__,
-				[ 'ORDER BY' => 'rla_type ASC, rla_page ASC, rla_wiki ASC' ]
+				[ 'ORDER BY' => 'rla_priority DESC, rla_type ASC, rla_page ASC, rla_wiki ASC' ]
 			);
 			foreach ( $res as $row ) {
 				if ( $row->rla_type === 'script' ) {

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -43,7 +43,7 @@ class MainHookHandler implements
 				'*',
 				[ '`rla_wiki` IN(\'' . $scriptPath . '\', \'all\')' ],
 				__METHOD__,
-				[ 'ORDER BY' => 'rla_priority DESC, rla_type ASC, rla_page ASC, rla_wiki ASC' ]
+				[ 'ORDER BY' => 'rla_type ASC, rla_priority DESC, rla_page ASC, rla_wiki ASC' ]
 			);
 			foreach ( $res as $row ) {
 				if ( $row->rla_type === 'script' ) {

--- a/src/Hooks/SchemaHookHandler.php
+++ b/src/Hooks/SchemaHookHandler.php
@@ -20,6 +20,10 @@ class SchemaHookHandler implements
 			$updater->output( "Creating resourceloaderarticles table resourceloaderarticles ...\n" );
 			$db->sourceFile( __DIR__ . '/../sql/resourceloaderarticles.sql' );
 			$updater->output( "done.\n" );
+		} elseif ( !$db->fieldExists( 'resourceloaderarticles', 'rla_priority', __METHOD__ ) ) {
+			$updater->output( "Adding `rla_priority` field to resourceloaderarticles table resourceloaderarticles ...\n" );
+			$db->sourceFile( __DIR__ . '/../sql/resourceloaderarticlesPriorityMigration.sql' );
+			$updater->output( "done.\n" );
 		} else {
 			$updater->output( "...resourceloaderarticles table already exists.\n" );
 		}

--- a/src/Hooks/SchemaHookHandler.php
+++ b/src/Hooks/SchemaHookHandler.php
@@ -21,7 +21,7 @@ class SchemaHookHandler implements
 			$db->sourceFile( __DIR__ . '/../sql/resourceloaderarticles.sql' );
 			$updater->output( "done.\n" );
 		} elseif ( !$db->fieldExists( 'resourceloaderarticles', 'rla_priority', __METHOD__ ) ) {
-			$updater->output( "Adding `rla_priority` field to resourceloaderarticles table resourceloaderarticles ...\n" );
+			$updater->output( "Adding `rla_priority` to resourceloaderarticles table resourceloaderarticles ...\n" );
 			$db->sourceFile( __DIR__ . '/../sql/resourceloaderarticlesPriorityMigration.sql' );
 			$updater->output( "done.\n" );
 		} else {

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -123,6 +123,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
+				'help' => $this->msg( 'resourceloaderarticles-help-priority' )->text(),
 				'type' => 'number',
 				'required' => true,
 				'default' => '0',
@@ -242,6 +243,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
+				'help' => $this->msg( 'resourceloaderarticles-help-priority' )->text(),
 				'type' => 'number',
 				'required' => true,
 				'default' => $row->rla_priority,
@@ -368,6 +370,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
+				'help' => $this->msg( 'resourceloaderarticles-help-priority' )->text(),
 				'type' => 'number',
 				'required' => true,
 				'disabled' => true,

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -67,11 +67,13 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			'*',
 			[],
 			__METHOD__,
-			[ 'ORDER BY' => 'rla_type ASC, rla_page ASC, rla_wiki ASC' ]
+			[ 'ORDER BY' => 'rla_priority DESC, rla_type ASC, rla_page ASC, rla_wiki ASC' ]
 		);
 		$output->addHTML( '<div class="table-responsive"><table class="wikitable">' );
 		$output->addHTML(
-			'<tr><th>#</th><th>' . $this->msg( 'resourceloaderarticles-page' )->text()
+			'<tr><th>' . $this->msg( 'resourceloaderarticles-id' )->text()
+			. '</th><th>' . $this->msg( 'resourceloaderarticles-priority' )->text()
+			. '</th><th>' . $this->msg( 'resourceloaderarticles-page' )->text()
 			. '</th><th>' . $this->msg( 'resourceloaderarticles-wiki' )->text()
 			. '</th><th>' . $this->msg( 'resourceloaderarticles-type' )->text()
 			. '</th><th></th></tr>'
@@ -81,6 +83,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			$editTitle = Title::newFromText( 'ResourceLoaderArticles/edit/' . $row->rla_id, NS_SPECIAL );
 			$output->addHTML(
 				'<tr><td>' . $row->rla_id
+				. '</td><td>' . $row->rla_priority
 				. '</td><td>' . $row->rla_page
 				. '</td><td>' . $row->rla_wiki
 				. '</td><td>' . $row->rla_type
@@ -117,6 +120,12 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 					'JavaScript' => 'script',
 					'CSS' => 'style',
 				],
+			],
+			'Priority' => [
+				'label-message' => 'resourceloaderarticles-priority',
+				'type' => 'number',
+				'required' => true,
+				'default' => '0',
 			],
 		];
 
@@ -163,6 +172,21 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			);
 			$store = false;
 		}
+		if ( empty( $formData[ 'Priority' ] ) ) {
+			$output->addWikiTextAsContent(
+				'<div class="error">'
+				. $this->msg( 'resourceloaderarticles-error-priority-empty' )->text()
+				. '</div>'
+			);
+			$store = false;
+		} elseif ( !is_int( $formData[ 'Priority' ] ) ) {
+			$output->addWikiTextAsContent(
+				'<div class="error">'
+				. $this->msg( 'resourceloaderarticles-error-priority-invalid' )->text()
+				. '</div>'
+			);
+			$store = false;
+		}
 		if ( $store ) {
 			$dbw = wfGetDB( DB_PRIMARY );
 			$dbw->insert(
@@ -170,7 +194,8 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 				[
 					'rla_page' => $formData[ 'Page' ],
 					'rla_wiki' => $formData[ 'Wiki' ],
-					'rla_type' => $formData[ 'Type' ]
+					'rla_type' => $formData[ 'Type' ],
+					'rla_priority' => $formData[ 'Priority' ]
 				]
 			);
 			$output->addWikiTextAsContent(
@@ -214,6 +239,12 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 					'CSS' => 'style',
 				],
 				'default' => $row->rla_type,
+			],
+			'Priority' => [
+				'label-message' => 'resourceloaderarticles-priority',
+				'type' => 'number',
+				'required' => true,
+				'default' => $row->rla_priority,
 			],
 		];
 
@@ -260,6 +291,21 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			);
 			$store = false;
 		}
+		if ( empty( $formData[ 'Priority' ] ) ) {
+			$output->addWikiTextAsContent(
+				'<div class="error">'
+				. $this->msg( 'resourceloaderarticles-error-priority-empty' )->text()
+				. '</div>'
+			);
+			$store = false;
+		} elseif ( !is_int( $formData[ 'Priority' ] ) ) {
+			$output->addWikiTextAsContent(
+				'<div class="error">'
+				. $this->msg( 'resourceloaderarticles-error-priority-invalid' )->text()
+				. '</div>'
+			);
+			$store = false;
+		}
 		if ( $store ) {
 			$dbw = wfGetDB( DB_PRIMARY );
 			$dbw->update(
@@ -267,7 +313,8 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 				[
 					'rla_page' => $formData[ 'Page' ],
 					'rla_wiki' => $formData[ 'Wiki' ],
-					'rla_type' => $formData[ 'Type' ]
+					'rla_type' => $formData[ 'Type' ],
+					'rla_priority' => $formData[ 'Priority' ]
 				],
 				[
 					'rla_id' => $formData[ 'Id' ]
@@ -314,6 +361,12 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 					'CSS' => 'style',
 				],
 				'default' => $row->rla_type,
+			],
+			'Priority' => [
+				'label-message' => 'resourceloaderarticles-priority',
+				'type' => 'number',
+				'required' => true,
+				'default' => $row->rla_priority,
 			],
 		];
 

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -339,18 +339,21 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			'Id' => [
 				'type' => 'hidden',
 				'required' => true,
+				'disabled' => true,
 				'default' => $row->rla_id,
 			],
 			'Page' => [
 				'label-message' => 'resourceloaderarticles-page',
 				'type' => 'text',
 				'required' => true,
+				'disabled' => true,
 				'default' => $row->rla_page,
 			],
 			'Wiki' => [
 				'label-message' => 'resourceloaderarticles-wiki',
 				'type' => 'text',
 				'required' => true,
+				'disabled' => true,
 				'default' => $row->rla_wiki,
 			],
 			'Type' => [
@@ -360,12 +363,14 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 					'JavaScript' => 'script',
 					'CSS' => 'style',
 				],
+				'disabled' => true,
 				'default' => $row->rla_type,
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
 				'type' => 'number',
 				'required' => true,
+				'disabled' => true,
 				'default' => $row->rla_priority,
 			],
 		];

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -67,7 +67,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			'*',
 			[],
 			__METHOD__,
-			[ 'ORDER BY' => 'rla_priority DESC, rla_type ASC, rla_page ASC, rla_wiki ASC' ]
+			[ 'ORDER BY' => 'rla_type ASC, rla_priority DESC, rla_page ASC, rla_wiki ASC' ]
 		);
 		$output->addHTML( '<div class="table-responsive"><table class="wikitable">' );
 		$output->addHTML(
@@ -78,9 +78,14 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			. '</th><th>' . $this->msg( 'resourceloaderarticles-type' )->text()
 			. '</th><th></th></tr>'
 		);
+		$prevResType = '';
 		foreach ( $res as $row ) {
 			$deleteTitle = Title::newFromText( 'ResourceLoaderArticles/delete/' . $row->rla_id, NS_SPECIAL );
 			$editTitle = Title::newFromText( 'ResourceLoaderArticles/edit/' . $row->rla_id, NS_SPECIAL );
+			if ( $prevResType !== $row->rla_type ) {
+				$output->addHTML( "<tr><th colspan='6'>{ $row->rla_type }s</th></tr>" );
+				$prevResType = $row->rla_type;
+			}
 			$output->addHTML(
 				'<tr><td>' . $row->rla_id
 				. '</td><td>' . $row->rla_priority

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -128,7 +128,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
-				'help-message' => 'resourceloaderarticles-help-priority' ),
+				'help-message' => 'resourceloaderarticles-help-priority',
 				'type' => 'number',
 				'required' => true,
 				'default' => '0',

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -128,7 +128,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
-				'help' => $this->msg( 'resourceloaderarticles-help-priority' )->text(),
+				'help-message' => 'resourceloaderarticles-help-priority' ),
 				'type' => 'number',
 				'required' => true,
 				'default' => '0',
@@ -248,7 +248,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
-				'help' => $this->msg( 'resourceloaderarticles-help-priority' )->text(),
+				'help-message' => 'resourceloaderarticles-help-priority',
 				'type' => 'number',
 				'required' => true,
 				'default' => $row->rla_priority,
@@ -375,7 +375,7 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 			],
 			'Priority' => [
 				'label-message' => 'resourceloaderarticles-priority',
-				'help' => $this->msg( 'resourceloaderarticles-help-priority' )->text(),
+				'help-message' => 'resourceloaderarticles-help-priority',
 				'type' => 'number',
 				'required' => true,
 				'disabled' => true,


### PR DESCRIPTION
## Summary

As discussed previously in the Lua & Commons Resources repo, adding priority field to RLA extension so that we can order them based on more than just alphabetical order.

Also disabled editing the form fields on the delete form.

## How did you test this change?

Untested as I don't have a test wiki. Please test before merging.