### PR TITLE
add scss parsing to the extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"require": {
-		"mck89/peast": "^1.16"
+		"mck89/peast": "^1.16",
+		"scssphp/scssphp": "^1.13.0"
 	},
 	"require-dev": {
 		"liquipedia/sqllint": "*",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "ResourceLoaderArticles",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"author": [
 		"[https://fo-nttax.de Alex Winkler]"
 	],

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -32,5 +32,5 @@
 	"resourceloaderarticles-success-delete": "Resource successfully deleted",
 
 	"resourceloaderarticles-help-page": "Page name of resource (excl. `MediaWiki:Common.[js|css]/`). Valid JS ends with `.js` and valid styling ends with `.css` or `.less`.",
-	"resourceloaderarticles-help-priority": "Priority for loading order of the resource (higher first), falls back to alphabetic order within a single priority class."
+	"resourceloaderarticles-help-priority": "Priority for loading order of the resource (higher first), falls back to alphabetic order within a single priority class. Priority is done in two groups: Less/CSS and SCSS. The first group will always be before the second."
 }

--- a/src/Hooks/MainHookHandler.php
+++ b/src/Hooks/MainHookHandler.php
@@ -83,7 +83,7 @@ class MainHookHandler implements
 	}
 
 	/**
-	 * Set the CONTENT_MODEL_CSS content handler for less files
+	 * Set the CONTENT_MODEL_CSS content handler for less and scss files
 	 *
 	 * @param Title $title
 	 * @param string &$model
@@ -92,6 +92,9 @@ class MainHookHandler implements
 	public function onContentHandlerDefaultModelFor( $title, &$model ) {
 		if ( $title->getNamespace() === NS_MEDIAWIKI ) {
 			if ( str_ends_with( $title->getText(), '.less' ) ) {
+				$model = CONTENT_MODEL_CSS;
+				return true;
+			} elseif ( str_ends_with( $title->getText(), '.scss' ) ) {
 				$model = CONTENT_MODEL_CSS;
 				return true;
 			}

--- a/src/ResourceLoader/ResourceLoaderArticlesModule.php
+++ b/src/ResourceLoader/ResourceLoaderArticlesModule.php
@@ -141,7 +141,7 @@ class ResourceLoaderArticlesModule extends ResourceLoaderWikiModule {
 			$compiler = new SCSSCompiler();
 			$compiledScss = $compiler->compileString( $scss )->getCss();
 		} catch ( \Exception $e ) {
-			$compiledLess = '/* invalid less: ' . $e->getMessage() . ' */';
+			$compiledScss = '/* invalid less: ' . $e->getMessage() . ' */';
 		}
 		/* end of scss parser */
 

--- a/src/ResourceLoader/ResourceLoaderArticlesModule.php
+++ b/src/ResourceLoader/ResourceLoaderArticlesModule.php
@@ -104,7 +104,6 @@ class ResourceLoaderArticlesModule extends ResourceLoaderWikiModule {
 	 * @return array
 	 */
 	public function getStyles( ResourceLoaderContext $context ) {
-		$styles = [ 'all' => [ '' ] ];
 		$less = '';
 		$scss = '';
 		foreach ( $this->getPages( $context ) as $titleText => $options ) {

--- a/src/ResourceLoader/ResourceLoaderArticlesModule.php
+++ b/src/ResourceLoader/ResourceLoaderArticlesModule.php
@@ -141,7 +141,7 @@ class ResourceLoaderArticlesModule extends ResourceLoaderWikiModule {
 			$compiler = new SCSSCompiler();
 			$compiledScss = $compiler->compileString( $scss )->getCss();
 		} catch ( \Exception $e ) {
-			$compiledScss = '/* invalid less: ' . $e->getMessage() . ' */';
+			$compiledScss = '/* invalid scss: ' . $e->getMessage() . ' */';
 		}
 		/* end of scss parser */
 

--- a/src/SpecialPage/SpecialResourceLoaderArticles.php
+++ b/src/SpecialPage/SpecialResourceLoaderArticles.php
@@ -346,11 +346,18 @@ class SpecialResourceLoaderArticles extends \SpecialPage {
 	 */
 	public function validatePageCB( $value, $alldata ) {
 		if (
-			( $alldata[ 'Type' ] === 'style'
-				&& !( ( strlen( $value ) > 4 && substr( $value, -4 ) === '.css' )
+			(
+				$alldata[ 'Type' ] === 'style'
+				&& !(
+					( strlen( $value ) > 4 && substr( $value, -4 ) === '.css' )
 					|| ( strlen( $value ) > 5 && substr( $value, -5 ) === '.less' )
+					|| ( strlen( $value ) > 5 && substr( $value, -5 ) === '.scss' )
 				)
-			) || ( $alldata[ 'Type' ] === 'script' && !( strlen( $value ) > 3 && substr( $value, -3 ) === '.js' ) )
+			)
+			|| (
+				$alldata[ 'Type' ] === 'script'
+				&& !( strlen( $value ) > 3 && substr( $value, -3 ) === '.js' )
+			)
 		) {
 			return $this->msg( 'resourceloaderarticles-error-page-invalid' )->text();
 		}


### PR DESCRIPTION
This adds the ability to parse SCSS pages in addition to Less and CSS (treated as Less) pages to the extension. SCSS content will always load after Less content. This is needed for our transition tot he Lighthouse project as well as enabling more modern CSS features like container queries.